### PR TITLE
Restore missing copyright header

### DIFF
--- a/src/main/java/cuchaz/enigma/mapping/MappingsReaderOld.java
+++ b/src/main/java/cuchaz/enigma/mapping/MappingsReaderOld.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Jeff Martin.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Lesser General Public
+ * License v3.0 which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/lgpl.html
+ * <p>
+ * Contributors:
+ * Jeff Martin - initial API and implementation
+ ******************************************************************************/
 package cuchaz.enigma.mapping;
 
 import com.google.common.collect.Queues;


### PR DESCRIPTION
Renamed MappingsReaderOld.java from MappingsReader.java (chuchaz/enigma) but lost copyright header.